### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+lexer.c linguist-generated
+lexer.l linguist-language=Flex
+parser.h linguist-generated
+parser.c linguist-generated
+parser.y linguist-language=Bison


### PR DESCRIPTION
This will hide the lexer/parser generated files from github diffs so you only see the Flex and Bison code files, not the generated files.

Couldn't resist adding this since I know how this works!